### PR TITLE
Feature: Add ability for variables to have underscores in names

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -421,7 +421,7 @@ named!(paragraph_rest<CompleteStr, Node>, do_parse!(
   (Node::Text{children: word})));
 
 named!(identifier<CompleteStr, Node>, do_parse!(
-  identifier: map!(tuple!(count!(word,1), many0!(alt!(dash | slash | word | number))), |tuple| {
+  identifier: map!(tuple!(count!(word,1), many0!(alt!(dash | slash | word | number | underscore))), |tuple| {
     let (mut word, mut rest) = tuple;
     word.append(&mut rest);
     word

--- a/tests/compiler.rs
+++ b/tests/compiler.rs
@@ -139,6 +139,12 @@ block
 block
   #test = #ball.x + #ball.y * #ball.vx", Value::from_i64(177));
 
+test_mech!(math_multiple_rows_select_underscores,"
+block
+  #stream_probe = [discharge: 5 stream_width: 2 stream_depth: 2]
+block
+  #test = #stream_probe.stream_width * #stream_probe.stream_depth * #stream_probe.discharge", Value::from_i64(20));
+
 test_mech!(math_const_and_select,"
 block
   #ball = [x: 15 y: 9 vx: 18 vy: 0]


### PR DESCRIPTION
As the title states, this slightly modifies the identifier portion of the parser to accept an underscore as valid, as long as it isn't leading. 

**Tests:**
All previous tests passed, and I included another one which works specifically with underscores, which also passed.